### PR TITLE
Delete prefix requirement for appIndex redirect.

### DIFF
--- a/packages/dev-server-core/src/middleware/historyApiFallbackMiddleware.ts
+++ b/packages/dev-server-core/src/middleware/historyApiFallbackMiddleware.ts
@@ -35,10 +35,6 @@ export function historyApiFallbackMiddleware(
       return next();
     }
 
-    if (!ctx.url.startsWith(appIndexBrowserPathPrefix)) {
-      return next();
-    }
-
     // rewrite url and let static serve take it further
     logger.debug(`Rewriting ${ctx.url} to app index ${appIndexBrowserPath}`);
     ctx.url = appIndexBrowserPath;


### PR DESCRIPTION
See issue #1334 for context.

## What I did

1.
